### PR TITLE
Removes the directory dependency of CSS inclusion

### DIFF
--- a/homepage.html
+++ b/homepage.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8" />
 	<title>Homepage</title>
 
-	<link rel="stylesheet" href="file:///D:/Homepage/main.css" type="text/css" />
+	<link rel="stylesheet" href="main.css" type="text/css" />
 	<script src="script.js"></script>
 
 </head>


### PR DESCRIPTION
The current CSS link is dependent on a file directory hierarchy of Jamie's computer. Removed it.
